### PR TITLE
Feature 68

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "primeng": "^11.2.0",
     "quill": "^1.3.7",
     "rxjs": "~6.6.3",
-    "systelab-components": "^13.0.0",
+    "systelab-components": "^13.3.3",
     "systelab-preferences": "^9.0.0",
     "systelab-translate": "^11.0.0",
     "tslib": "^2.1.0",

--- a/projects/showcase/src/styles.scss
+++ b/projects/showcase/src/styles.scss
@@ -1,1 +1,3 @@
 @import "systelab-components/sass/systelab-components";
+// Uncomment following line to test with new modern styles
+// @import "systelab-components/sass/modern/systelab-components";

--- a/projects/systelab-login/src/lib/change-password-dialog.component.html
+++ b/projects/systelab-login/src/lib/change-password-dialog.component.html
@@ -42,7 +42,7 @@
     </form>
 </div>
 <systelab-dialog-bottom>
-    <button type="button" class="btn btn-outline-primary ml-auto"
+    <button type="button" class="btn btn-primary ml-auto"
             [disabled]="!isOK() || !passwordIndicator.isOK()"
             (click)="changePassword()">{{ 'COMMON_SUBMIT' | translate | async}}
     </button>

--- a/projects/systelab-login/src/lib/login.component.scss
+++ b/projects/systelab-login/src/lib/login.component.scss
@@ -193,10 +193,3 @@ small.badge-warning{
 .slab-form_input:disabled,.btn:disabled{
   cursor:no-drop;
 }
-
-
-
-
-
-
-


### PR DESCRIPTION
# PR Details

Changed ```change password``` button class from ```btn-outline-primary``` to ```btn-primary```

![image](https://user-images.githubusercontent.com/5593621/149135206-a80b2795-df8b-4b27-a94e-79148656b3d3.png)

## Related Issue

#68 

## How Has This Been Tested

Cosmetic changes. They don't need to be tested.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
