### PR TITLE
Allow app URL for external authentication

### DIFF
--- a/projects/showcase/src/app/app.component.html
+++ b/projects/showcase/src/app/app.component.html
@@ -23,4 +23,5 @@
                 [applicationName]="'App Name'" [moduleName]="'Module'" [version]="'1.4. (build 2012)'"
                 [isLoading]="isLoading"
                 [noticeText]="'Notice Text'"
-                [pathExternalLogin]="pathExternalLogin"></systelab-login>
+                [pathExternalLogin]="pathExternalLogin"
+                [useAppUrl]="useAppUrl"></systelab-login>

--- a/projects/showcase/src/app/app.component.ts
+++ b/projects/showcase/src/app/app.component.ts
@@ -25,6 +25,7 @@ export class AppComponent {
 	public pathTerms = 'http://www.werfen.com/en/terms-and-conditions';
 	public pathPrivacy = 'http://www.werfen.com/en/privacy-policy';
 	public pathExternalLogin = 'http://www.werfen.com';
+	public useAppUrl = false;
 	public isRecoveryActive = true;
 	public isSignUpActive = true;
 	public isLoginActive = true;

--- a/projects/systelab-login/package.json
+++ b/projects/systelab-login/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-login",
-  "version": "15.1.0",
+  "version": "15.2.0",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-login/src/lib/README.md
+++ b/projects/systelab-login/src/lib/README.md
@@ -36,7 +36,8 @@ This is an example with the three components enabled.
                 [applicationName]="'App Name'" [moduleName]="'Module'" [version]="'1.4. (build 2012)'"
                 [isLoading]="isLoading"
                 [noticeText]="'Notice Text'"
-                [pathExternalLogin]="pathExternalLogin">
+                [pathExternalLogin]="pathExternalLogin"
+                [useAppUrl]="useAppUrl">
                 </systelab-login>
 ```
 
@@ -58,7 +59,8 @@ This is an example with the three components enabled.
                 [txtUsername]="txtUsername"
                 [applicationName]="'App Name'" [moduleName]="'Module'" [version]="'1.4. (build 2012)'" [isLoading]="isLoading"
                 [noticeText]="'Notice Text'"
-                [pathExternalLogin]="pathExternalLogin">
+                [pathExternalLogin]="pathExternalLogin"
+                [useAppUrl]="useAppUrl">
                 </systelab-login>
 ```
 
@@ -83,7 +85,8 @@ This is an example with the three components enabled.
                 [pathPrivacy]="pathPrivacy"
                 [applicationName]="'App Name'" [moduleName]="'Module'" [version]="'1.4. (build 2012)'" [isLoading]="isLoading"
                 [noticeText]="'Notice Text'"
-                [pathExternalLogin]="pathExternalLogin">
+                [pathExternalLogin]="pathExternalLogin"
+                [useAppUrl]="useAppUrl">
                 </systelab-login>
 ```
 
@@ -104,7 +107,8 @@ This is an example with the three components enabled.
                 [txtRecoverProcessStarted]="txtRecoverProcessStarted"
                 [applicationName]="'App Name'" [moduleName]="'Module'" [version]="'1.4. (build 2012)'" [isLoading]="isLoading"
                 [noticeText]="'Notice Text'"
-                [pathExternalLogin]="pathExternalLogin">
+                [pathExternalLogin]="pathExternalLogin"
+                [useAppUrl]="useAppUrl">
                 </systelab-login>
 ```
 

--- a/projects/systelab-login/src/lib/form-login/form-login.component.html
+++ b/projects/systelab-login/src/lib/form-login/form-login.component.html
@@ -18,8 +18,14 @@
 </div>
 
 <div *ngIf="pathExternalLogin" class="slab-form_input--marginTop15 text-center">
-    <a class="slab-text slab-text--link"
-       href="{{pathExternalLogin}}">{{ 'COMMON_EXTERNAL_LOGIN' | translate | async }}</a>
+    <ng-container *ngIf="useAppUrl else useExternalLink">
+        <a class="slab-text slab-text--link"
+           routerLink="{{pathExternalLogin}}">{{ 'COMMON_EXTERNAL_LOGIN' | translate | async }}</a>
+    </ng-container>
+    <ng-template #useExternalLink>
+        <a class="slab-text slab-text--link"
+           href="{{pathExternalLogin}}">{{ 'COMMON_EXTERNAL_LOGIN' | translate | async }}</a>
+    </ng-template>
 </div>
 
 <div *ngIf="errorUserPwd" class="alert alert-danger text-center slab-form_input--marginTop25">

--- a/projects/systelab-login/src/lib/form-login/form-login.component.ts
+++ b/projects/systelab-login/src/lib/form-login/form-login.component.ts
@@ -14,6 +14,7 @@ export class FormLoginComponent implements OnInit {
 	@Input() public isLoading = false;
 	@Input() public maxUsernameLength = 20;
 	@Input() public pathExternalLogin = undefined;
+	@Input() public useAppUrl = false;
 
 	@Output() userNameChange = new EventEmitter();
 	@Output() public passwordChange = new EventEmitter();

--- a/projects/systelab-login/src/lib/login.component.html
+++ b/projects/systelab-login/src/lib/login.component.html
@@ -23,7 +23,8 @@
                                 [(currentForm)]="currentForm"
                                 [isLoading]="isLoading"
                                 [maxUsernameLength]="maxUsernameLength"
-                                [pathExternalLogin]="pathExternalLogin">
+                                [pathExternalLogin]="pathExternalLogin"
+                                [useAppUrl]="useAppUrl">
                 </slt-form-login>
             </form>
         </div>

--- a/projects/systelab-login/src/lib/login.component.ts
+++ b/projects/systelab-login/src/lib/login.component.ts
@@ -36,6 +36,7 @@ export class LoginComponent implements OnInit {
 	@Input() public pathTerms = undefined;
 	@Input() public pathPrivacy = undefined;
 	@Input() public pathExternalLogin = undefined;
+	@Input() public useAppUrl = false;
 	@Input() public maxUsernameLength = 20;
 
 	@Output() public userNameChange = new EventEmitter();

--- a/projects/systelab-login/src/lib/systelab-login.module.ts
+++ b/projects/systelab-login/src/lib/systelab-login.module.ts
@@ -12,13 +12,15 @@ import {FormRecoveryComponent} from './form-recovery/form-recovery.component';
 import {PasswordIndicatorComponent} from './password-indicator/password-indicator.component';
 import {AllowedRolesDirective} from './role-directives/allowed-roles.directive';
 import {ForbiddenRolesDirective} from './role-directives/forbidden-roles.directive';
+import {RouterLink} from "@angular/router";
 
 @NgModule({
     imports: [
         CommonModule,
         FormsModule,
         SystelabTranslateModule,
-        SystelabComponentsModule
+        SystelabComponentsModule,
+        RouterLink
     ],
     declarations: [
         LoginComponent,


### PR DESCRIPTION
# PR Details
Allow app URL for external authentication

## Description
Enable the option to allow external authentication via a URL from our app (with router link)

## Related Issue
#140  

## Motivation and Context
Enable the option to allow external authentication via a URL from our app (with router link).If the option is disabled, the expected behaviour will not change regarding the previous one (href).

## How Has This Been Tested

This improvement has been tested in a real project.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] I have read the **CONTRIBUTING** document
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation 
- [X] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [ ] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [X] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [X] Add the issue into the right [project](https://github.com/systelab/systelab-login/projects) with the proper status (In progress)