### PR TITLE
146 - When press enter only click the Normal Login Button

### DIFF
--- a/projects/systelab-login/package.json
+++ b/projects/systelab-login/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-login",
-  "version": "15.4.0",
+  "version": "15.5.0",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-login/src/lib/form-login/form-login.component.html
+++ b/projects/systelab-login/src/lib/form-login/form-login.component.html
@@ -9,7 +9,7 @@
     <a href="#" class="slab-text slab-text--link" (click)="goRecovery()">{{ 'COMMON_FORGOT_PASSWORD' | translate | async }}</a>
 </div>
 
-<button type="button" class="w-100 btn btn-primary slab-form__submit mt-4" [disabled]="inputUserName.invalid ||  inputPassword.invalid"
+<button type="submit" class="w-100 btn btn-primary slab-form__submit mt-4" [disabled]="inputUserName.invalid ||  inputPassword.invalid"
         (click)="doLogin()">{{ 'COMMON_ENTER' | translate | async }}
 </button>
 
@@ -18,7 +18,7 @@
 </div>
 
 <div class="slab-form_input--marginTop15 text-center" *ngIf="isExternalLoginActive">
-    <button class="btn btn-link" (click)="doExternalLogin()">{{ 'COMMON_EXTERNAL_LOGIN' | translate | async }}</button>
+    <button type="button" class="btn btn-link" (click)="doExternalLogin()">{{ 'COMMON_EXTERNAL_LOGIN' | translate | async }}</button>
 </div>
 
 <div *ngIf="errorUserPwd" class="alert alert-danger text-center slab-form_input--marginTop25">


### PR DESCRIPTION
PR Details
Allow normal login when press enter key.

Description
When the enter key is pressed, click the Login Button.

Related Issue
https://github.com/systelab/systelab-login/issues/146

Motivation and Context

Now when the enter key it's pressed, it clicks the normal login but also clicks the external login.

How Has This Been Tested
This improvement has been tested in a real project.

Types of changes


- [ ]  Docs change / refactoring / dependency upgrade
- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to change)


Checklist


- [x] I have read the CONTRIBUTING document
- [x]  My code follows the code style of this project
- [ ]  My change requires a change to the documentation
- [ ]  I have updated the documentation accordingly (README.md for each UI component)
- [ ]  I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [ ]  All new and existing tests passed
- [ ]  A new branch needs to be created from master to evolve previous versions
- [x]  Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x]  All UI components must be added into the showcase (at least 1 component with the default settings)
- [x]  Add the issue into the right [project](https://github.com/systelab/systelab-login/projects) with the proper status (In progress)