### PR TITLE
Show username parameter in change password dialog when filled

### DIFF
--- a/projects/showcase/src/i18n/language/MessagesBundle_en.json
+++ b/projects/showcase/src/i18n/language/MessagesBundle_en.json
@@ -19,7 +19,6 @@
 	"COMMON_CREATE_NEW_ACCOUNT":"Create a new account",
 	"COMMON_FORGOT_PASSWORD":"Forgot you password?",
 	"COMMON_CHANGE_PASSWORD":"Change Password",
-	"LOGIN_ENTER_PASSWORD_USERNAME":"Username",
 	"LOGIN_ENTER_OLDPASSWORD":"Old Password",
 	"LOGIN_ENTER_NEWPASSWORD":"New Password",
 	"LOGIN_REPEAT_NEWPASSWORD":"Repeat New Password",

--- a/projects/showcase/src/i18n/language/MessagesBundle_en.json
+++ b/projects/showcase/src/i18n/language/MessagesBundle_en.json
@@ -19,6 +19,7 @@
 	"COMMON_CREATE_NEW_ACCOUNT":"Create a new account",
 	"COMMON_FORGOT_PASSWORD":"Forgot you password?",
 	"COMMON_CHANGE_PASSWORD":"Change Password",
+	"LOGIN_ENTER_PASSWORD_USERNAME":"Username",
 	"LOGIN_ENTER_OLDPASSWORD":"Old Password",
 	"LOGIN_ENTER_NEWPASSWORD":"New Password",
 	"LOGIN_REPEAT_NEWPASSWORD":"Repeat New Password",

--- a/projects/systelab-login/package.json
+++ b/projects/systelab-login/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-login",
-  "version": "17.0.0",
+  "version": "17.1.0",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-login/src/lib/change-password-dialog.component.html
+++ b/projects/systelab-login/src/lib/change-password-dialog.component.html
@@ -3,8 +3,8 @@
     <form class="w-100 h-100 p-3" (keypress)="($event.which === 13 && isOK()) ? changePassword() : 0"
           autocomplete="off">
 
-        <div class="row mt-1 pb-2" *ngIf="dialog.context.userName">
-            <label class="col-md-6 col-form-label">{{ 'LOGIN_ENTER_PASSWORD_USERNAME' |	translate | async }}</label>
+        <div class="row mt-1 pb-2" *ngIf="showUsernameField">
+            <label class="col-md-6 col-form-label">{{ 'COMMON_USERNAME' | translate | async }}</label>
             <label class="col-md-6 col-form-label font-weight-bold">{{ dialog.context.userName }}</label>
         </div>
 

--- a/projects/systelab-login/src/lib/change-password-dialog.component.html
+++ b/projects/systelab-login/src/lib/change-password-dialog.component.html
@@ -2,6 +2,12 @@
 <div class="slab-change-password slab-flex-1">
     <form class="w-100 h-100 p-3" (keypress)="($event.which === 13 && isOK()) ? changePassword() : 0"
           autocomplete="off">
+
+        <div class="row mt-1 pb-2" *ngIf="dialog.context.userName">
+            <label class="col-md-6 col-form-label">{{ 'LOGIN_ENTER_PASSWORD_USERNAME' |	translate | async }}</label>
+            <label class="col-md-6 col-form-label font-weight-bold">{{ dialog.context.userName }}</label>
+        </div>
+
         <div class="row mt-1" *ngIf="showOldPasswordField">
             <label for="form-h-it" class="col-md-6 col-form-label">{{ 'LOGIN_ENTER_OLDPASSWORD' |
                 translate | async}}</label>

--- a/projects/systelab-login/src/lib/change-password-dialog.component.spec.ts
+++ b/projects/systelab-login/src/lib/change-password-dialog.component.spec.ts
@@ -7,6 +7,7 @@ export class ChangePasswordDialogParametersMock {
     public minPasswordStrengthValue = 1;
     public action: (oldPassword: string, newPassword: string) => Observable<boolean>;
     public hasNumpad = false;
+    public showUsernameField = true;
 }
 
 describe('ChangePasswordDialogParameter', () => {
@@ -16,9 +17,10 @@ describe('ChangePasswordDialogParameter', () => {
         expect(parameters.hasNumpad).toBeFalsy();
     });
 
-    it('should set userName by default in change password dialog', () => {
+    it('should set userName and display the info in change password dialog', () => {
         const parameters = new ChangePasswordDialogParametersMock();
 
+        expect(parameters.showUsernameField).toBeTrue();
         expect(parameters.userName.length).toBeGreaterThan(0);
     });
 });

--- a/projects/systelab-login/src/lib/change-password-dialog.component.spec.ts
+++ b/projects/systelab-login/src/lib/change-password-dialog.component.spec.ts
@@ -3,7 +3,7 @@ import {Observable} from 'rxjs';
 export class ChangePasswordDialogParametersMock {
     public width = 550;
     public maxHeight = 360;
-    public userName: string;
+    public userName = "test userName";
     public minPasswordStrengthValue = 1;
     public action: (oldPassword: string, newPassword: string) => Observable<boolean>;
     public hasNumpad = false;
@@ -14,5 +14,11 @@ describe('ChangePasswordDialogParameter', () => {
         const parameters = new ChangePasswordDialogParametersMock();
 
         expect(parameters.hasNumpad).toBeFalsy();
+    });
+
+    it('should set userName by default in change password dialog', () => {
+        const parameters = new ChangePasswordDialogParametersMock();
+
+        expect(parameters.userName.length).toBeGreaterThan(0);
     });
 });

--- a/projects/systelab-login/src/lib/change-password-dialog.component.ts
+++ b/projects/systelab-login/src/lib/change-password-dialog.component.ts
@@ -11,6 +11,7 @@ export class ChangePasswordDialogParameters extends SystelabModalContext {
 	public showOldPasswordField = true;
 	public action: (oldPassword: string, newPassword: string) => Observable<boolean>;
 	public hasNumpad = false;
+	public showUsernameField = false;
 }
 
 @Component({
@@ -27,11 +28,13 @@ export class ChangePasswordDialog implements ModalComponent<ChangePasswordDialog
 	public repeatedPassword: string;
 	public oldPassword: string;
 	public showOldPasswordField = true;
+	public showUsernameField = false;
 
 	constructor(public dialog: DialogRef<ChangePasswordDialogParameters>,
 							protected i18nService: I18nService, protected messagePopupService: MessagePopupService) {
 		this.parameters = dialog.context;
 		this.showOldPasswordField = this.parameters.showOldPasswordField;
+		this.showUsernameField = this.parameters.showUsernameField;
 	}
 
 	public static getParameters(): ChangePasswordDialogParameters {


### PR DESCRIPTION
# PR Details

Show username in the change password dialog

## Description

Show username in the change password dialog when filled

## Related Issue

#154  

## Motivation and Context

The Anthema project requires that the username be shown in the change password dialog if this one is populated to identify the user whose password is being changed. 

## How Has This Been Tested

This improvement has been tested with a mock.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] I have read the **CONTRIBUTING** document
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [X] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [X] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [X] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [X] Add the issue into the right [project](https://github.com/systelab/systelab-login/projects) with the proper status (In progress)